### PR TITLE
Request to Merge

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -1374,6 +1374,38 @@ public final class Util {
   }
 
   /**
+   * Returns the total duration (in microseconds) of {@code sampleCount} samples of equal duration
+   * at {@code sampleRate}.
+   *
+   * <p>If {@code sampleRate} is less than {@link C#MICROS_PER_SECOND}, the duration produced by
+   * this method can be reversed to the original sample count using {@link
+   * #durationUsToSampleCount(long, int)}.
+   *
+   * @param sampleCount The number of samples.
+   * @param sampleRate The sample rate, in samples per second.
+   * @return The total duration, in microseconds, of {@code sampleCount} samples.
+   */
+  public static long sampleCountToDurationUs(long sampleCount, int sampleRate) {
+    return (sampleCount * C.MICROS_PER_SECOND) / sampleRate;
+  }
+
+  /**
+   * Returns the number of samples required to represent {@code durationUs} of media at {@code
+   * sampleRate}, assuming all samples are equal duration except the last one which may be shorter.
+   *
+   * <p>The result of this method <b>cannot</b> be generally reversed to the original duration with
+   * {@link #sampleCountToDurationUs(long, int)}, due to information lost when rounding to a whole
+   * number of samples.
+   *
+   * @param durationUs The duration in microseconds.
+   * @param sampleRate The sample rate in samples per second.
+   * @return The number of samples required to represent {@code durationUs}.
+   */
+  public static long durationUsToSampleCount(long durationUs, int sampleRate) {
+    return Util.ceilDivide(durationUs * sampleRate, C.MICROS_PER_SECOND);
+  }
+
+  /**
    * Parses an xs:duration attribute value, returning the parsed duration in milliseconds.
    *
    * @param value The attribute value to decode.

--- a/library/common/src/test/java/com/google/android/exoplayer2/util/UtilTest.java
+++ b/library/common/src/test/java/com/google/android/exoplayer2/util/UtilTest.java
@@ -27,6 +27,7 @@ import static com.google.android.exoplayer2.util.Util.parseXsDateTime;
 import static com.google.android.exoplayer2.util.Util.parseXsDuration;
 import static com.google.android.exoplayer2.util.Util.unescapeFileName;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -830,6 +831,21 @@ public class UtilTest {
   @Test
   public void sparseLongArrayMaxValue_emptyArray_throws() {
     assertThrows(NoSuchElementException.class, () -> maxValue(new SparseLongArray()));
+  }
+
+  @Test
+  public void sampleCountToDuration_thenDurationToSampleCount_returnsOriginalValue() {
+    // Use co-prime increments, to maximise 'discord' between sampleCount and sampleRate.
+    for (long originalSampleCount = 0; originalSampleCount < 100_000; originalSampleCount += 97) {
+      for (int sampleRate = 89; sampleRate < 1_000_000; sampleRate += 89) {
+        long calculatedSampleCount =
+            Util.durationUsToSampleCount(
+                Util.sampleCountToDurationUs(originalSampleCount, sampleRate), sampleRate);
+        assertWithMessage("sampleCount=%s, sampleRate=%s", originalSampleCount, sampleRate)
+            .that(calculatedSampleCount)
+            .isEqualTo(originalSampleCount);
+      }
+    }
   }
 
   @Test

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
@@ -2079,11 +2079,11 @@ public final class DefaultAudioSink implements AudioSink {
     }
 
     public long inputFramesToDurationUs(long frameCount) {
-      return (frameCount * C.MICROS_PER_SECOND) / inputFormat.sampleRate;
+      return Util.sampleCountToDurationUs(frameCount, inputFormat.sampleRate);
     }
 
     public long framesToDurationUs(long frameCount) {
-      return (frameCount * C.MICROS_PER_SECOND) / outputSampleRate;
+      return Util.sampleCountToDurationUs(frameCount, outputSampleRate);
     }
 
     public AudioTrack buildAudioTrack(


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixed a bug in `AudioTrackPositionTracker` by using ceiling division logic to correctly determine when audio playback has ended.
- Introduced new utility methods `sampleCountToDurationUs` and `durationUsToSampleCount` for converting between sample counts and durations.
- Updated `AudioTrackPositionTracker` and `DefaultAudioSink` to use these new utility methods, improving code clarity and correctness.
- Added tests to ensure the new utility methods work as expected, maintaining the original sample count after conversions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Util.java</strong><dd><code>Add utility methods for sample count and duration conversion</code></dd></summary>
<hr>

library/common/src/main/java/com/google/android/exoplayer2/util/Util.java

<li>Added <code>sampleCountToDurationUs</code> method to calculate duration from sample <br>count.<br> <li> Added <code>durationUsToSampleCount</code> method to calculate sample count from <br>duration.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/1/files#diff-1608c5ba9a31afce221167d32abaf50731febc0dd78ccfdd7afee06353d06527">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultAudioSink.java</strong><dd><code>Refactor duration calculation in DefaultAudioSink</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java

<li>Replaced manual duration calculation with <code>sampleCountToDurationUs</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/1/files#diff-57d5144a268eb472e14dcda480deb7d2c0f3d16363e40e823f1e48a0cd1b4546">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UtilTest.java</strong><dd><code>Add tests for sample count and duration conversion methods</code></dd></summary>
<hr>

library/common/src/test/java/com/google/android/exoplayer2/util/UtilTest.java

<li>Added test for <code>sampleCountToDurationUs</code> and <code>durationUsToSampleCount</code> <br>methods.<br> <li> Ensured conversion methods return original sample count.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/1/files#diff-64c0e973f1a9d29babcdf7386713b7a4bffaa3b464dd7eee38aa7379e6d5cefa">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AudioTrackPositionTracker.java</strong><dd><code>Use new utility methods for audio track position tracking</code></dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/audio/AudioTrackPositionTracker.java

<li>Replaced <code>framesToDurationUs</code> and <code>durationUsToFrames</code> with new utility <br>methods.<br> <li> Fixed logic in <code>hasPendingData</code> using <code>durationUsToSampleCount</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/1/files#diff-5cfb54b07c48f31540cce3924eb55b4c3187a2e285b3825543bc7b0b81524fc3">+18/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information