### PR TITLE
Request to Merge

### DIFF
--- a/library/container/src/main/java/com/google/android/exoplayer2/util/NalUnitUtil.java
+++ b/library/container/src/main/java/com/google/android/exoplayer2/util/NalUnitUtil.java
@@ -621,8 +621,8 @@ public final class NalUnitUtil {
     }
     skipShortTermReferencePictureSets(data);
     if (data.readBit()) { // long_term_ref_pics_present_flag
-      // num_long_term_ref_pics_sps
-      for (int i = 0; i < data.readUnsignedExpGolombCodedInt(); i++) {
+      int numLongTermRefPicsSps = data.readUnsignedExpGolombCodedInt();
+      for (int i = 0; i < numLongTermRefPicsSps; i++) {
         int ltRefPicPocLsbSpsLength = log2MaxPicOrderCntLsbMinus4 + 4;
         // lt_ref_pic_poc_lsb_sps[i], used_by_curr_pic_lt_sps_flag[i]
         data.skipBits(ltRefPicPocLsbSpsLength + 1);
@@ -944,12 +944,14 @@ public final class NalUnitUtil {
         numPositivePics = bitArray.readUnsignedExpGolombCodedInt();
         deltaPocS0 = new int[numNegativePics];
         for (int i = 0; i < numNegativePics; i++) {
-          deltaPocS0[i] = bitArray.readUnsignedExpGolombCodedInt() + 1;
+          deltaPocS0[i] =
+              (i > 0 ? deltaPocS0[i - 1] : 0) - (bitArray.readUnsignedExpGolombCodedInt() + 1);
           bitArray.skipBit(); // used_by_curr_pic_s0_flag[i]
         }
         deltaPocS1 = new int[numPositivePics];
         for (int i = 0; i < numPositivePics; i++) {
-          deltaPocS1[i] = bitArray.readUnsignedExpGolombCodedInt() + 1;
+          deltaPocS1[i] =
+              (i > 0 ? deltaPocS1[i - 1] : 0) + (bitArray.readUnsignedExpGolombCodedInt() + 1);
           bitArray.skipBit(); // used_by_curr_pic_s1_flag[i]
         }
       }

--- a/library/container/src/test/java/com/google/android/exoplayer2/util/NalUnitUtilTest.java
+++ b/library/container/src/test/java/com/google/android/exoplayer2/util/NalUnitUtilTest.java
@@ -200,11 +200,40 @@ public final class NalUnitUtilTest {
     assertThat(spsData.colorTransfer).isEqualTo(6);
   }
 
+  /** Regression test for [Internal: b/292170736]. */
+  @Test
+  public void parseH265SpsNalUnitPayload_withShortTermRefPicSets() {
+    byte[] spsNalUnitPayload =
+        new byte[] {
+          1, 2, 96, 0, 0, 3, 0, 0, 3, 0, 0, 3, 0, 0, 3, 0, -106, -96, 2, 28, -128, 30, 4, -39, 111,
+          -110, 76, -114, -65, -7, -13, 101, 33, -51, 66, 68, 2, 65, 0, 0, 3, 0, 1, 0, 0, 3, 0, 29,
+          8
+        };
+
+    NalUnitUtil.H265SpsData spsData =
+        NalUnitUtil.parseH265SpsNalUnitPayload(spsNalUnitPayload, 0, spsNalUnitPayload.length);
+
+    assertThat(spsData.constraintBytes).isEqualTo(new int[] {0, 0, 0, 0, 0, 0});
+    assertThat(spsData.generalLevelIdc).isEqualTo(150);
+    assertThat(spsData.generalProfileCompatibilityFlags).isEqualTo(6);
+    assertThat(spsData.generalProfileIdc).isEqualTo(2);
+    assertThat(spsData.generalProfileSpace).isEqualTo(0);
+    assertThat(spsData.generalTierFlag).isFalse();
+    assertThat(spsData.width).isEqualTo(1080);
+    assertThat(spsData.height).isEqualTo(1920);
+    assertThat(spsData.pixelWidthHeightRatio).isEqualTo(1);
+    assertThat(spsData.seqParameterSetId).isEqualTo(0);
+    assertThat(spsData.chromaFormatIdc).isEqualTo(1);
+    assertThat(spsData.bitDepthLumaMinus8).isEqualTo(2);
+    assertThat(spsData.bitDepthChromaMinus8).isEqualTo(2);
+    assertThat(spsData.colorSpace).isEqualTo(6);
+    assertThat(spsData.colorRange).isEqualTo(2);
+    assertThat(spsData.colorTransfer).isEqualTo(6);
+  }
+
   private static byte[] buildTestData() {
     byte[] data = new byte[20];
-    for (int i = 0; i < data.length; i++) {
-      data[i] = (byte) 0xFF;
-    }
+    Arrays.fill(data, (byte) 0xFF);
     // Insert an incomplete NAL unit start code.
     data[TEST_PARTIAL_NAL_POSITION] = 0;
     data[TEST_PARTIAL_NAL_POSITION + 1] = 0;


### PR DESCRIPTION
### **User description**
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the parsing logic for long-term reference pictures and delta POC in the `NalUnitUtil` class of the ExoPlayer library.

### Why are these changes being made?

The changes improve code clarity and correctness by introducing local variables (`numLongTermRefPicsSps`) and updating delta POC calculation to ensure proper consecutive addition and subtraction within the parsing loops, which aligns with the standard handling of reference pictures. These updates help maintain correct picture ordering count and optimize bit reading operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactored the parsing logic for long-term reference pictures in the `NalUnitUtil` class to improve clarity and correctness.
- Updated the delta POC calculation to align with the H.265/HEVC specification, ensuring proper handling of reference pictures.
- Introduced a local variable `numLongTermRefPicsSps` to optimize bit reading operations.
- Added a regression test to verify the parsing of short-term reference picture sets in H.265 SPS NAL unit payloads.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NalUnitUtil.java</strong><dd><code>Refactor and fix H.265 SPS parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/container/src/main/java/com/google/android/exoplayer2/util/NalUnitUtil.java

<li>Refactored parsing logic for long-term reference pictures.<br> <li> Updated delta POC calculation for correctness.<br> <li> Introduced local variable <code>numLongTermRefPicsSps</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/2/files#diff-31cb09a40d9720bff494823fe844468f514843e08e90b39e8622674a958d9378">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NalUnitUtilTest.java</strong><dd><code>Add regression test for H.265 SPS parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/container/src/test/java/com/google/android/exoplayer2/util/NalUnitUtilTest.java

<li>Added regression test for short-term reference picture sets.<br> <li> Verified parsing of H.265 SPS NAL unit payload.<br> <li> Used <code>Arrays.fill</code> for test data initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/2/files#diff-ce407238500000c9494f63b59be91b844c84624b21ee4c2c4dc599a17de8e5b0">+32/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information