### PR TITLE
Request to Merge

### DIFF
--- a/demos/main/src/main/java/com/google/android/exoplayer2/demo/DownloadTracker.java
+++ b/demos/main/src/main/java/com/google/android/exoplayer2/demo/DownloadTracker.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.fragment.app.FragmentManager;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.RenderersFactory;
@@ -50,6 +51,7 @@ import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.Util;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -208,7 +210,7 @@ public class DownloadTracker {
         return;
       }
       // TODO(internal b/163107948): Support cases where DrmInitData are not in the manifest.
-      if (!hasSchemaData(format.drmInitData)) {
+      if (!hasNonNullWidevineSchemaData(format.drmInitData)) {
         Toast.makeText(context, R.string.download_start_error_offline_license, Toast.LENGTH_LONG)
             .show();
         Log.e(
@@ -329,12 +331,14 @@ public class DownloadTracker {
     }
 
     /**
-     * Returns whether any the {@link DrmInitData.SchemeData} contained in {@code drmInitData} has
-     * non-null {@link DrmInitData.SchemeData#data}.
+     * Returns whether any {@link DrmInitData.SchemeData} that {@linkplain
+     * DrmInitData.SchemeData#matches(UUID) matches} {@link C#WIDEVINE_UUID} has non-null {@link
+     * DrmInitData.SchemeData#data}.
      */
-    private boolean hasSchemaData(DrmInitData drmInitData) {
+    private boolean hasNonNullWidevineSchemaData(DrmInitData drmInitData) {
       for (int i = 0; i < drmInitData.schemeDataCount; i++) {
-        if (drmInitData.get(i).hasData()) {
+        DrmInitData.SchemeData schemeData = drmInitData.get(i);
+        if (schemeData.matches(C.WIDEVINE_UUID) && schemeData.hasData()) {
           return true;
         }
       }


### PR DESCRIPTION
### **User description**
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update `DownloadTracker` to improve DRM schema data checks by renaming the `hasSchemaData` method to `hasNonNullWidevineSchemaData` and enhancing its logic to focus on Widevine UUIDs.

### Why are these changes being made?

These changes address a specific issue with the DRM schema data validation by ensuring that only Widevine UUIDs with non-null data are acknowledged, aligning the function with intended DRM requirements and improving code clarity. This resolves a limitation where non-relevant schema data was previously processed, potentially preventing proper handling of DRM-protected content downloads.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


___

### **PR Type**
enhancement


___

### **Description**
- Renamed the method `hasSchemaData` to `hasNonNullWidevineSchemaData` to better reflect its purpose.
- Enhanced the logic to ensure that only Widevine UUIDs with non-null data are processed, improving DRM schema data validation.
- Added necessary imports for `UUID` and `C` to support the new logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DownloadTracker.java</strong><dd><code>Improve DRM schema data validation for Widevine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

demos/main/src/main/java/com/google/android/exoplayer2/demo/DownloadTracker.java

<li>Renamed method <code>hasSchemaData</code> to <code>hasNonNullWidevineSchemaData</code>.<br> <li> Enhanced logic to check for Widevine UUID with non-null data.<br> <li> Added import for <code>UUID</code> and <code>C</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/3/files#diff-7e7a345f728f032f9c389416c3e1325daf7c7784d015d45a800b8f629cddf18f">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information