### PR TITLE
Request to Merge

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ClippingMediaPeriod.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ClippingMediaPeriod.java
@@ -331,6 +331,7 @@ public final class ClippingMediaPeriod implements MediaPeriod, MediaPeriod.Callb
         buffer.setFlags(C.BUFFER_FLAG_END_OF_STREAM);
         return C.RESULT_BUFFER_READ;
       }
+      long bufferedPositionUs = getBufferedPositionUs();
       @ReadDataResult int result = childStream.readData(formatHolder, buffer, readFlags);
       if (result == C.RESULT_FORMAT_READ) {
         Format format = Assertions.checkNotNull(formatHolder.format);
@@ -350,7 +351,7 @@ public final class ClippingMediaPeriod implements MediaPeriod, MediaPeriod.Callb
       if (endUs != C.TIME_END_OF_SOURCE
           && ((result == C.RESULT_BUFFER_READ && buffer.timeUs >= endUs)
               || (result == C.RESULT_NOTHING_READ
-                  && getBufferedPositionUs() == C.TIME_END_OF_SOURCE
+                  && bufferedPositionUs == C.TIME_END_OF_SOURCE
                   && !buffer.waitingForKeys))) {
         buffer.clear();
         buffer.setFlags(C.BUFFER_FLAG_END_OF_STREAM);

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ads/ServerSideAdInsertionMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ads/ServerSideAdInsertionMediaSource.java
@@ -872,6 +872,7 @@ public final class ServerSideAdInsertionMediaSource extends BaseMediaSource
         @SampleStream.ReadFlags int readFlags) {
       @SampleStream.ReadFlags
       int peekingFlags = readFlags | SampleStream.FLAG_PEEK | SampleStream.FLAG_OMIT_SAMPLE_DATA;
+      long bufferedPositionUs = getBufferedPositionUs(mediaPeriod);
       @SampleStream.ReadDataResult
       int result =
           castNonNull(sampleStreams[streamIndex]).readData(formatHolder, buffer, peekingFlags);
@@ -879,7 +880,7 @@ public final class ServerSideAdInsertionMediaSource extends BaseMediaSource
           getMediaPeriodPositionUsWithEndOfSourceHandling(mediaPeriod, buffer.timeUs);
       if ((result == C.RESULT_BUFFER_READ && adjustedTimeUs == C.TIME_END_OF_SOURCE)
           || (result == C.RESULT_NOTHING_READ
-              && getBufferedPositionUs(mediaPeriod) == C.TIME_END_OF_SOURCE
+              && bufferedPositionUs == C.TIME_END_OF_SOURCE
               && !buffer.waitingForKeys)) {
         maybeNotifyDownstreamFormatChanged(mediaPeriod, streamIndex);
         buffer.clear();

--- a/library/core/src/test/java/com/google/android/exoplayer2/source/ClippingMediaPeriodTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/source/ClippingMediaPeriodTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer2.source;
+
+import static com.google.android.exoplayer2.testutil.FakeSampleStream.FakeSampleStreamItem.END_OF_STREAM_ITEM;
+import static com.google.android.exoplayer2.testutil.FakeSampleStream.FakeSampleStreamItem.oneByteSample;
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.FormatHolder;
+import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
+import com.google.android.exoplayer2.drm.DrmSessionEventListener;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.robolectric.RobolectricUtil;
+import com.google.android.exoplayer2.testutil.FakeMediaPeriod;
+import com.google.android.exoplayer2.testutil.FakeSampleStream;
+import com.google.android.exoplayer2.trackselection.ExoTrackSelection;
+import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
+import com.google.android.exoplayer2.upstream.Allocator;
+import com.google.android.exoplayer2.upstream.DefaultAllocator;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Unit tests for {@link ClippingMediaPeriod}. */
+@RunWith(AndroidJUnit4.class)
+public class ClippingMediaPeriodTest {
+
+  @Test
+  public void fastLoadingStreamAfterFirstRead_canBeReadFully() throws Exception {
+    TrackGroup trackGroup = new TrackGroup(new Format.Builder().build());
+    // Set up MediaPeriod with no samples and only add samples after the first SampleStream read.
+    FakeMediaPeriod mediaPeriod =
+        new FakeMediaPeriod(
+            new TrackGroupArray(trackGroup),
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* trackDataFactory= */ (format, mediaPeriodId) -> ImmutableList.of(),
+            new MediaSourceEventListener.EventDispatcher()
+                .withParameters(
+                    /* windowIndex= */ 0,
+                    new MediaSource.MediaPeriodId(/* periodUid= */ new Object())),
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* deferOnPrepared= */ false) {
+          @Override
+          protected FakeSampleStream createSampleStream(
+              Allocator allocator,
+              @Nullable MediaSourceEventListener.EventDispatcher mediaSourceEventDispatcher,
+              DrmSessionManager drmSessionManager,
+              DrmSessionEventListener.EventDispatcher drmEventDispatcher,
+              Format initialFormat,
+              List<FakeSampleStream.FakeSampleStreamItem> fakeSampleStreamItems) {
+            return new FakeSampleStream(
+                allocator,
+                mediaSourceEventDispatcher,
+                drmSessionManager,
+                drmEventDispatcher,
+                initialFormat,
+                /* fakeSampleStreamItems= */ ImmutableList.of()) {
+              private boolean addedSamples = false;
+
+              @Override
+              public int readData(
+                  FormatHolder formatHolder, DecoderInputBuffer buffer, @ReadFlags int readFlags) {
+                int result = super.readData(formatHolder, buffer, readFlags);
+                if (!addedSamples) {
+                  append(
+                      ImmutableList.of(
+                          oneByteSample(/* timeUs= */ 0, C.BUFFER_FLAG_KEY_FRAME),
+                          oneByteSample(/* timeUs= */ 200, C.BUFFER_FLAG_KEY_FRAME),
+                          oneByteSample(/* timeUs= */ 400, C.BUFFER_FLAG_KEY_FRAME),
+                          oneByteSample(/* timeUs= */ 600, C.BUFFER_FLAG_KEY_FRAME),
+                          oneByteSample(/* timeUs= */ 800, C.BUFFER_FLAG_KEY_FRAME),
+                          END_OF_STREAM_ITEM));
+                  writeData(/* startPositionUs= */ 0);
+                  addedSamples = true;
+                }
+                return result;
+              }
+            };
+          }
+        };
+    ClippingMediaPeriod clippingMediaPeriod =
+        new ClippingMediaPeriod(
+            mediaPeriod,
+            /* enableInitialDiscontinuity= */ true,
+            /* startUs= */ 0,
+            /* endUs= */ 500);
+    AtomicBoolean periodPrepared = new AtomicBoolean();
+    clippingMediaPeriod.prepare(
+        new MediaPeriod.Callback() {
+          @Override
+          public void onPrepared(MediaPeriod mediaPeriod) {
+            periodPrepared.set(true);
+          }
+
+          @Override
+          public void onContinueLoadingRequested(MediaPeriod source) {
+            clippingMediaPeriod.continueLoading(/* positionUs= */ 0);
+          }
+        },
+        /* positionUs= */ 0);
+    RobolectricUtil.runMainLooperUntil(periodPrepared::get);
+    SampleStream[] sampleStreams = new SampleStream[1];
+    clippingMediaPeriod.selectTracks(
+        new ExoTrackSelection[] {new FixedTrackSelection(trackGroup, /* track= */ 0)},
+        /* mayRetainStreamFlags= */ new boolean[] {false},
+        sampleStreams,
+        /* streamResetFlags= */ new boolean[] {true},
+        /* positionUs= */ 0);
+    FormatHolder formatHolder = new FormatHolder();
+    DecoderInputBuffer buffer =
+        new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_NORMAL);
+    ArrayList<Long> readSamples = new ArrayList<>();
+
+    int result;
+    do {
+      result = sampleStreams[0].readData(formatHolder, buffer, /* readFlags= */ 0);
+      if (result == C.RESULT_BUFFER_READ && !buffer.isEndOfStream()) {
+        readSamples.add(buffer.timeUs);
+      }
+    } while (result != C.RESULT_BUFFER_READ || !buffer.isEndOfStream());
+
+    assertThat(readSamples).containsExactly(0L, 200L, 400L).inOrder();
+  }
+}


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a race condition in `ClippingMediaPeriod` and `ServerSideAdInsertionMediaSource` by adjusting the order of operations to ensure buffered position checks occur before sample reading.
- Added comprehensive unit tests for `ClippingMediaPeriod` to verify behavior with fast loading streams.
- Introduced tests for `ServerSideAdInsertionMediaSource` to ensure sample streams can be fully read after initial loading.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClippingMediaPeriod.java</strong><dd><code>Fix race condition in ClippingMediaPeriod sample reading</code>&nbsp; </dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/source/ClippingMediaPeriod.java

<li>Fixed race condition by moving buffered position check before reading <br>samples.<br> <li> Ensured buffered position does not exceed the time of reading "no <br>sample".<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/4/files#diff-6c52c15a785bc1fd2557dfc27ffe8392e5f15b41f39ced0d6221fb3194810c06">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ServerSideAdInsertionMediaSource.java</strong><dd><code>Adjust buffered position check in ServerSideAdInsertionMediaSource</code></dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/source/ads/ServerSideAdInsertionMediaSource.java

<li>Adjusted buffered position check to prevent race conditions.<br> <li> Ensured buffered position consistency during sample reading.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/4/files#diff-c212781dc3a543d31449822087bad288afb623168cd0d0981a76bbd32bcce974">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClippingMediaPeriodTest.java</strong><dd><code>Add unit tests for ClippingMediaPeriod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/core/src/test/java/com/google/android/exoplayer2/source/ClippingMediaPeriodTest.java

<li>Added unit tests for ClippingMediaPeriod.<br> <li> Tested fast loading stream after first read.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/4/files#diff-f5e29a517c18cecee95a3ffdfde8703c9856e07e1138fc77222609a39b777668">+145/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ServerSideAdInsertionMediaSourceTest.java</strong><dd><code>Add test for ServerSideAdInsertionMediaSource fast loading</code></dd></summary>
<hr>

library/core/src/test/java/com/google/android/exoplayer2/source/ads/ServerSideAdInsertionMediaSourceTest.java

<li>Added test for fast loading source in <br>ServerSideAdInsertionMediaSource.<br> <li> Verified full reading of sample streams.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/4/files#diff-fe88936daff03d198ef19adf1b6ec316af6100d1a1b89358816a9ed9bb178ad8">+143/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information