### PR TITLE
Request to Merge

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/PlaylistTimeline.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/PlaylistTimeline.java
@@ -17,6 +17,7 @@ package com.google.android.exoplayer2;
 
 import com.google.android.exoplayer2.source.ForwardingTimeline;
 import com.google.android.exoplayer2.source.ShuffleOrder;
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.google.android.exoplayer2.util.Util;
 import java.util.Arrays;
 import java.util.Collection;
@@ -123,15 +124,43 @@ import java.util.List;
     return periodCount;
   }
 
+  /**
+   * Creates a copy of the timeline and wraps each child timeline with a {@link ForwardingTimeline}
+   * that overrides {@link Timeline#getPeriod(int, Period, boolean)} to set the {@link
+   * Period#isPlaceholder} flag.
+   *
+   * <p>For periods of a live window, the {@link AdPlaybackState} is set to {@link
+   * AdPlaybackState#NONE} to allow a live source with ad support to drop the ad playback state.
+   *
+   * <p>This method should be used when the player is reset (for instance when a playback error
+   * occurs or {@link Player#stop()} is called) to make the player resolve the start position like
+   * when prepared initially. In this state, each source needs to be prepared again at which point
+   * the first timeline delivered by the source will replace the wrapped source to continue
+   * playback.
+   */
   public PlaylistTimeline copyWithPlaceholderTimeline(ShuffleOrder shuffleOrder) {
     Timeline[] newTimelines = new Timeline[timelines.length];
     for (int i = 0; i < timelines.length; i++) {
       newTimelines[i] =
           new ForwardingTimeline(timelines[i]) {
+            private final Window window = new Window();
+
             @Override
             public Period getPeriod(int periodIndex, Period period, boolean setIds) {
               Period superPeriod = super.getPeriod(periodIndex, period, setIds);
-              superPeriod.isPlaceholder = true;
+              if (super.getWindow(superPeriod.windowIndex, window).isLive()) {
+                // Reset the ad playback state for placeholder period of a live streams.
+                superPeriod.set(
+                    period.id,
+                    period.uid,
+                    period.windowIndex,
+                    period.durationUs,
+                    period.positionInWindowUs,
+                    AdPlaybackState.NONE,
+                    /* isPlaceholder= */ true);
+              } else {
+                superPeriod.isPlaceholder = true;
+              }
               return superPeriod;
             }
           };


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed an `ArrayIndexOutOfBoundException` when re-preparing a live stream with server-side inserted ads after a playback exception.
- Modified `ExoPlayerImplInternal` to remove ad metadata from the current period for live streams, allowing the ad playback state to be reset.
- Enhanced `PlaylistTimeline` to wrap child timelines and reset ad playback state for live windows, ensuring proper handling of live streams with ads.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExoPlayerImplInternal.java</strong><dd><code>Fix ad metadata handling for live stream re-preparation</code>&nbsp; &nbsp; </dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java

<li>Modified logic to handle ad metadata for live streams.<br> <li> Ensured ad playback state can be reset for live streams.<br> <li> Updated timeline handling for live stream re-preparation.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/6/files#diff-e28981d4e9226392779a53d772bd531c6cd8e4bc802775705c3ec9c57208fb35">+12/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PlaylistTimeline.java</strong><dd><code>Enhance timeline handling for live streams with ads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/PlaylistTimeline.java

<li>Added logic to reset ad playback state for live streams.<br> <li> Enhanced <code>copyWithPlaceholderTimeline</code> to handle live periods.<br> <li> Introduced <code>AdPlaybackState.NONE</code> for live window periods.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/6/files#diff-f958aa20790dd9149e4907c3ab5a0b3c1e446fd9108c02179215add247932be2">+30/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information