### PR TITLE
Request to Merge

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallback.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallback.java
@@ -134,10 +134,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public int dequeueInputBufferIndex() {
     synchronized (lock) {
+      maybeThrowException();
       if (isFlushingOrShutdown()) {
         return MediaCodec.INFO_TRY_AGAIN_LATER;
       } else {
-        maybeThrowException();
         return availableInputBuffers.isEmpty()
             ? MediaCodec.INFO_TRY_AGAIN_LATER
             : availableInputBuffers.remove();
@@ -153,10 +153,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public int dequeueOutputBufferIndex(MediaCodec.BufferInfo bufferInfo) {
     synchronized (lock) {
+      maybeThrowException();
       if (isFlushingOrShutdown()) {
         return MediaCodec.INFO_TRY_AGAIN_LATER;
       } else {
-        maybeThrowException();
         if (availableOutputBuffers.isEmpty()) {
           return MediaCodec.INFO_TRY_AGAIN_LATER;
         } else {

--- a/library/core/src/test/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallbackTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallbackTest.java
@@ -30,6 +30,7 @@ import android.os.Looper;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
@@ -103,6 +104,36 @@ public class AsynchronousMediaCodecCallbackTest {
     assertThat(flushCompleted.get()).isFalse();
     assertThat(asynchronousMediaCodecCallback.dequeueInputBufferIndex())
         .isEqualTo(MediaCodec.INFO_TRY_AGAIN_LATER);
+  }
+
+  @Test
+  public void dequeInputBufferIndex_withPendingFlushAndError_throwsError() throws Exception {
+    AtomicBoolean beforeFlushCompletes = new AtomicBoolean();
+    AtomicBoolean flushCompleted = new AtomicBoolean();
+    Looper callbackThreadLooper = callbackThread.getLooper();
+    Handler callbackHandler = new Handler(callbackThreadLooper);
+    ShadowLooper shadowCallbackLooper = shadowOf(callbackThreadLooper);
+    // Pause the callback thread so that flush() never completes.
+    shadowCallbackLooper.pause();
+
+    // Send two input buffers to the callback, then an error, and then flush().
+    asynchronousMediaCodecCallback.onInputBufferAvailable(codec, 0);
+    asynchronousMediaCodecCallback.onInputBufferAvailable(codec, 1);
+    MediaCodec.CodecException expectedException = createCodecException();
+    asynchronousMediaCodecCallback.onError(codec, expectedException);
+    callbackHandler.post(() -> beforeFlushCompletes.set(true));
+    asynchronousMediaCodecCallback.flush();
+    callbackHandler.post(() -> flushCompleted.set(true));
+    while (!beforeFlushCompletes.get()) {
+      shadowCallbackLooper.runOneTask();
+    }
+
+    assertThat(flushCompleted.get()).isFalse();
+    MediaCodec.CodecException actualException =
+        assertThrows(
+            MediaCodec.CodecException.class,
+            () -> asynchronousMediaCodecCallback.dequeueInputBufferIndex());
+    assertThat(actualException).isSameInstanceAs(expectedException);
   }
 
   @Test
@@ -216,6 +247,39 @@ public class AsynchronousMediaCodecCallbackTest {
     assertThat(flushCompleted.get()).isFalse();
     assertThat(asynchronousMediaCodecCallback.dequeueOutputBufferIndex(new MediaCodec.BufferInfo()))
         .isEqualTo(MediaCodec.INFO_TRY_AGAIN_LATER);
+  }
+
+  @Test
+  public void dequeOutputBufferIndex_withPendingFlushAndError_throwsError() throws Exception {
+    AtomicBoolean beforeFlushCompletes = new AtomicBoolean();
+    AtomicBoolean flushCompleted = new AtomicBoolean();
+    Looper callbackThreadLooper = callbackThread.getLooper();
+    Handler callbackHandler = new Handler(callbackThreadLooper);
+    ShadowLooper shadowCallbackLooper = shadowOf(callbackThreadLooper);
+    // Pause the callback thread so that flush() never completes.
+    shadowCallbackLooper.pause();
+
+    // Send two output buffers to the callback, then an error, and then flush().
+    MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
+    asynchronousMediaCodecCallback.onOutputBufferAvailable(codec, 0, bufferInfo);
+    asynchronousMediaCodecCallback.onOutputBufferAvailable(codec, 1, bufferInfo);
+    MediaCodec.CodecException expectedException = createCodecException();
+    asynchronousMediaCodecCallback.onError(codec, expectedException);
+    callbackHandler.post(() -> beforeFlushCompletes.set(true));
+    asynchronousMediaCodecCallback.flush();
+    callbackHandler.post(() -> flushCompleted.set(true));
+    while (beforeFlushCompletes.get()) {
+      shadowCallbackLooper.runOneTask();
+    }
+
+    assertThat(flushCompleted.get()).isFalse();
+    MediaCodec.CodecException actualException =
+        assertThrows(
+            MediaCodec.CodecException.class,
+            () ->
+                asynchronousMediaCodecCallback.dequeueOutputBufferIndex(
+                    new MediaCodec.BufferInfo()));
+    assertThat(actualException).isSameInstanceAs(expectedException);
   }
 
   @Test
@@ -438,13 +502,24 @@ public class AsynchronousMediaCodecCallbackTest {
   }
 
   @Test
-  public void flush_withPendingError_resetsError() throws Exception {
-    asynchronousMediaCodecCallback.onError(codec, createCodecException());
-    // Calling flush should clear any pending error.
-    asynchronousMediaCodecCallback.flush();
+  public void flush_withPendingError_doesntResetError() throws Exception {
+    AtomicBoolean flushCompleted = new AtomicBoolean();
+    Looper callbackThreadLooper = callbackThread.getLooper();
+    ShadowLooper shadowCallbackLooper = shadowOf(callbackThreadLooper);
 
-    assertThat(asynchronousMediaCodecCallback.dequeueInputBufferIndex())
-        .isEqualTo(MediaCodec.INFO_TRY_AGAIN_LATER);
+    MediaCodec.CodecException expectedException = createCodecException();
+    asynchronousMediaCodecCallback.onError(codec, expectedException);
+    // Flush and progress the looper so that flush is completed.
+    asynchronousMediaCodecCallback.flush();
+    new Handler(callbackThreadLooper).post(() -> flushCompleted.set(true));
+    shadowCallbackLooper.idle();
+
+    assertThat(flushCompleted.get()).isTrue();
+    MediaCodec.CodecException actualException =
+        assertThrows(
+            MediaCodec.CodecException.class,
+            () -> asynchronousMediaCodecCallback.dequeueInputBufferIndex());
+    assertThat(actualException).isSameInstanceAs(expectedException);
   }
 
   @Test
@@ -456,7 +531,11 @@ public class AsynchronousMediaCodecCallbackTest {
   }
 
   /** Reflectively create a {@link MediaCodec.CodecException}. */
-  private static MediaCodec.CodecException createCodecException() throws Exception {
+  private static MediaCodec.CodecException createCodecException()
+      throws NoSuchMethodException,
+          InvocationTargetException,
+          IllegalAccessException,
+          InstantiationException {
     Constructor<MediaCodec.CodecException> constructor =
         MediaCodec.CodecException.class.getDeclaredConstructor(
             Integer.TYPE, Integer.TYPE, String.class);


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Adjusted the `AsynchronousMediaCodecCallback` to ensure exceptions are thrown during flush operations by moving the `maybeThrowException()` call to occur before checking if a flush or shutdown is pending.
- Added new tests to verify that exceptions are thrown during pending flush operations in both input and output buffer scenarios.
- Modified existing test to ensure that errors are not reset after a flush operation.
- Updated the method for creating `MediaCodec.CodecException` to handle specific exceptions, improving test reliability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AsynchronousMediaCodecCallback.java</strong><dd><code>Adjust exception handling during flush operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/core/src/main/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallback.java

<li>Moved <code>maybeThrowException()</code> call to occur before checking flush or <br>shutdown state.<br> <li> Ensures exceptions are thrown during flush operations.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/8/files#diff-fa17e4ad61b42e566de3060d2b169e13491d9c2fcc1c7c65c1190721a5ced5d3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AsynchronousMediaCodecCallbackTest.java</strong><dd><code>Add and update tests for exception handling during flush</code>&nbsp; </dd></summary>
<hr>

library/core/src/test/java/com/google/android/exoplayer2/mediacodec/AsynchronousMediaCodecCallbackTest.java

<li>Added tests to verify exceptions are thrown during pending flush.<br> <li> Modified test to ensure errors are not reset after flush.<br> <li> Updated exception creation method to handle specific exceptions.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/8/files#diff-5e4464c025da7418145027ab53b067ef07a365e0fe2066a833d5d0c8470248ee">+85/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information