### PR TITLE
Request to Merge

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -133,6 +133,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
   private final FullSegmentEncryptionKeyCache keyCache;
   private final PlayerId playerId;
   @Nullable private final CmcdConfiguration cmcdConfiguration;
+  private final long timestampAdjusterInitializationTimeoutMs;
 
   private boolean isPrimaryTimestampSource;
   private byte[] scratchSpace;
@@ -161,6 +162,9 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    * @param timestampAdjusterProvider A provider of {@link TimestampAdjuster} instances. If multiple
    *     {@link HlsChunkSource}s are used for a single playback, they should all share the same
    *     provider.
+   * @param timestampAdjusterInitializationTimeoutMs The timeout for the loading thread to wait for
+   *     the timestamp adjuster to initialize, in milliseconds. A timeout of zero is interpreted as
+   *     an infinite timeout.
    * @param muxedCaptionFormats List of muxed caption {@link Format}s. Null if no closed caption
    *     information is available in the multivariant playlist.
    */
@@ -172,6 +176,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       HlsDataSourceFactory dataSourceFactory,
       @Nullable TransferListener mediaTransferListener,
       TimestampAdjusterProvider timestampAdjusterProvider,
+      long timestampAdjusterInitializationTimeoutMs,
       @Nullable List<Format> muxedCaptionFormats,
       PlayerId playerId,
       @Nullable CmcdConfiguration cmcdConfiguration) {
@@ -180,6 +185,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     this.playlistUrls = playlistUrls;
     this.playlistFormats = playlistFormats;
     this.timestampAdjusterProvider = timestampAdjusterProvider;
+    this.timestampAdjusterInitializationTimeoutMs = timestampAdjusterInitializationTimeoutMs;
     this.muxedCaptionFormats = muxedCaptionFormats;
     this.playerId = playerId;
     this.cmcdConfiguration = cmcdConfiguration;
@@ -519,6 +525,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
             trackSelection.getSelectionData(),
             isPrimaryTimestampSource,
             timestampAdjusterProvider,
+            timestampAdjusterInitializationTimeoutMs,
             previous,
             /* mediaSegmentKey= */ keyCache.get(mediaSegmentKeyUri),
             /* initSegmentKey= */ keyCache.get(initSegmentKeyUri),

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
@@ -82,6 +82,7 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsPlaylistTracker.Pla
   private final boolean useSessionKeys;
   private final PlayerId playerId;
   private final HlsSampleStreamWrapper.Callback sampleStreamWrapperCallback;
+  private final long timestampAdjusterInitializationTimeoutMs;
 
   @Nullable private MediaPeriod.Callback mediaPeriodCallback;
   private int pendingPrepareCount;
@@ -116,6 +117,9 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsPlaylistTracker.Pla
    * @param metadataType The type of metadata to extract from the period.
    * @param useSessionKeys Whether to use #EXT-X-SESSION-KEY tags.
    * @param playerId The ID of the current player.
+   * @param timestampAdjusterInitializationTimeoutMs The timeout for the loading thread to wait for
+   *     the timestamp adjuster to initialize, in milliseconds. A timeout of zero is interpreted as
+   *     an infinite timeout.
    */
   public HlsMediaPeriod(
       HlsExtractorFactory extractorFactory,
@@ -132,7 +136,8 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsPlaylistTracker.Pla
       boolean allowChunklessPreparation,
       @HlsMediaSource.MetadataType int metadataType,
       boolean useSessionKeys,
-      PlayerId playerId) {
+      PlayerId playerId,
+      long timestampAdjusterInitializationTimeoutMs) {
     this.extractorFactory = extractorFactory;
     this.playlistTracker = playlistTracker;
     this.dataSourceFactory = dataSourceFactory;
@@ -148,6 +153,7 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsPlaylistTracker.Pla
     this.metadataType = metadataType;
     this.useSessionKeys = useSessionKeys;
     this.playerId = playerId;
+    this.timestampAdjusterInitializationTimeoutMs = timestampAdjusterInitializationTimeoutMs;
     sampleStreamWrapperCallback = new SampleStreamWrapperCallback();
     compositeSequenceableLoader =
         compositeSequenceableLoaderFactory.createCompositeSequenceableLoader();
@@ -779,6 +785,7 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsPlaylistTracker.Pla
             dataSourceFactory,
             mediaTransferListener,
             timestampAdjusterProvider,
+            timestampAdjusterInitializationTimeoutMs,
             muxedCaptionFormats,
             playerId,
             cmcdConfiguration);

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
@@ -111,6 +111,7 @@ public final class HlsMediaSource extends BaseMediaSource
     private @MetadataType int metadataType;
     private boolean useSessionKeys;
     private long elapsedRealTimeOffsetMs;
+    private long timestampAdjusterInitializationTimeoutMs;
 
     /**
      * Creates a new factory for {@link HlsMediaSource}s.
@@ -321,6 +322,21 @@ public final class HlsMediaSource extends BaseMediaSource
     }
 
     /**
+     * Sets the timeout for the loading thread to wait for the timestamp adjuster to initialize, in
+     * milliseconds.The default value is zero, which is interpreted as an infinite timeout.
+     *
+     * @param timestampAdjusterInitializationTimeoutMs The timeout in milliseconds. A timeout of
+     *     zero is interpreted as an infinite timeout.
+     * @return This factory, for convenience.
+     */
+    @CanIgnoreReturnValue
+    public Factory setTimestampAdjusterInitializationTimeoutMs(
+        long timestampAdjusterInitializationTimeoutMs) {
+      this.timestampAdjusterInitializationTimeoutMs = timestampAdjusterInitializationTimeoutMs;
+      return this;
+    }
+
+    /**
      * Sets the offset between {@link SystemClock#elapsedRealtime()} and the time since the Unix
      * epoch. By default, is it set to {@link C#TIME_UNSET}.
      *
@@ -370,7 +386,8 @@ public final class HlsMediaSource extends BaseMediaSource
           elapsedRealTimeOffsetMs,
           allowChunklessPreparation,
           metadataType,
-          useSessionKeys);
+          useSessionKeys,
+          timestampAdjusterInitializationTimeoutMs);
     }
 
     @Override
@@ -392,6 +409,7 @@ public final class HlsMediaSource extends BaseMediaSource
   private final HlsPlaylistTracker playlistTracker;
   private final long elapsedRealTimeOffsetMs;
   private final MediaItem mediaItem;
+  private final long timestampAdjusterInitializationTimeoutMs;
 
   private MediaItem.LiveConfiguration liveConfiguration;
   @Nullable private TransferListener mediaTransferListener;
@@ -408,7 +426,8 @@ public final class HlsMediaSource extends BaseMediaSource
       long elapsedRealTimeOffsetMs,
       boolean allowChunklessPreparation,
       @MetadataType int metadataType,
-      boolean useSessionKeys) {
+      boolean useSessionKeys,
+      long timestampAdjusterInitializationTimeoutMs) {
     this.localConfiguration = checkNotNull(mediaItem.localConfiguration);
     this.mediaItem = mediaItem;
     this.liveConfiguration = mediaItem.liveConfiguration;
@@ -423,6 +442,7 @@ public final class HlsMediaSource extends BaseMediaSource
     this.allowChunklessPreparation = allowChunklessPreparation;
     this.metadataType = metadataType;
     this.useSessionKeys = useSessionKeys;
+    this.timestampAdjusterInitializationTimeoutMs = timestampAdjusterInitializationTimeoutMs;
   }
 
   @Override
@@ -466,7 +486,8 @@ public final class HlsMediaSource extends BaseMediaSource
         allowChunklessPreparation,
         metadataType,
         useSessionKeys,
-        getPlayerId());
+        getPlayerId(),
+        timestampAdjusterInitializationTimeoutMs);
   }
 
   @Override

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
@@ -321,6 +321,7 @@ public class HlsChunkSourceTest {
         new DefaultHlsDataSourceFactory(new FakeDataSource.Factory()),
         /* mediaTransferListener= */ null,
         new TimestampAdjusterProvider(),
+        /* timestampAdjusterInitializationTimeoutMs= */ 0,
         /* muxedCaptionFormats= */ null,
         PlayerId.UNSET,
         cmcdConfiguration);

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriodTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriodTest.java
@@ -96,7 +96,8 @@ public final class HlsMediaPeriodTest {
               /* allowChunklessPreparation= */ true,
               HlsMediaSource.METADATA_TYPE_ID3,
               /* useSessionKeys= */ false,
-              PlayerId.UNSET);
+              PlayerId.UNSET,
+              /* timestampAdjusterInitializationTimeoutMs= */ 0);
         };
 
     MediaPeriodAsserts.assertGetStreamKeysAndManifestFilterIntegration(


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Introduced a timeout mechanism in `TimestampAdjuster` to prevent endless stalling during HLS playback.
- Added a new parameter `timestampAdjusterInitializationTimeoutMs` across multiple classes to configure the timeout duration.
- Enhanced error handling by throwing `TimeoutException` if the initialization exceeds the specified timeout.
- Updated relevant tests to accommodate the new timeout parameter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimestampAdjuster.java</strong><dd><code>Add timeout handling to TimestampAdjuster initialization</code>&nbsp; </dd></summary>
<hr>

library/common/src/main/java/com/google/android/exoplayer2/util/TimestampAdjuster.java

<li>Added timeout parameter to <code>sharedInitializeOrWait</code> method.<br> <li> Implemented logic to throw <code>TimeoutException</code> if initialization exceeds <br>timeout.<br> <li> Used <code>SystemClock.elapsedRealtime</code> to track wait duration.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-e542cbfc1413963110aa973d77487a7a0b195cea2b3581a2e20ce0c1451f7081">+30/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HlsChunkSource.java</strong><dd><code>Include timeout parameter in HlsChunkSource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java

<li>Added <code>timestampAdjusterInitializationTimeoutMs</code> field.<br> <li> Updated constructor to include timeout parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-a500e9307d881d3b7b6a92999132c39808322d24b6f6a4a57a1c0d03cd6cf513">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HlsMediaChunk.java</strong><dd><code>Handle timestamp adjuster timeout in HlsMediaChunk</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java

<li>Added <code>timestampAdjusterInitializationTimeoutMs</code> field.<br> <li> Updated <code>createInstance</code> method to include timeout parameter.<br> <li> Modified <code>prepareExtraction</code> method to handle <code>TimeoutException</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-bd58000a2cd4e090d2610ed536baef0ba8ac1f5d582c48f7cb3f2ef3a5a7f36e">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HlsMediaPeriod.java</strong><dd><code>Add timeout parameter to HlsMediaPeriod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java

<li>Added <code>timestampAdjusterInitializationTimeoutMs</code> field.<br> <li> Updated constructor to include timeout parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-c045eff585f63fe6d1eee7c51a3b2d8a8ba0a31cb1f6685cf984fafad3e0e8cb">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HlsMediaSource.java</strong><dd><code>Implement timeout configuration in HlsMediaSource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java

<li>Added <code>timestampAdjusterInitializationTimeoutMs</code> field.<br> <li> Updated <code>Factory</code> class to include method for setting timeout.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-a4b84b4fe9b3376829e4a0392cc374781feb97b61f95f6a2e35950ccb7419aa7">+24/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HlsChunkSourceTest.java</strong><dd><code>Update HlsChunkSourceTest for timeout parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java

<li>Updated test setup to include <code>timestampAdjusterInitializationTimeoutMs</code> <br>parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-0f2442ced1ae0bfa5ab62b40238a44682a0186d53342fe871137e8127162dda6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HlsMediaPeriodTest.java</strong><dd><code>Update HlsMediaPeriodTest for timeout parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriodTest.java

<li>Updated test setup to include <code>timestampAdjusterInitializationTimeoutMs</code> <br>parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/9/files#diff-61a90e2457c19267fe774371f8cf53872a86fe50fd3c6619ad91b43e7bc78b0c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information