### PR TITLE
Request to Merge

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaUtil.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaUtil.java
@@ -421,6 +421,7 @@ import java.util.Set;
     Map<Object, AdPlaybackState> adPlaybackStates = new HashMap<>();
     for (int i = adPlaybackState.removedAdGroupCount; i < adPlaybackState.adGroupCount; i++) {
       AdGroup adGroup = adPlaybackState.getAdGroup(/* adGroupIndex= */ i);
+      int mappedAdCount = 0;
       if (adGroup.timeUs == C.TIME_END_OF_SOURCE) {
         checkState(i == adPlaybackState.adGroupCount - 1);
         // The last ad group is a placeholder for a potential post roll. We can just stop here.
@@ -454,8 +455,10 @@ import java.util.Set;
                     adsId, adGroup, periodStartUs, periodDurationUs, window.isLive()));
             // Current period added as an ad period. Advance and look at the next period.
             periodIndex++;
+            mappedAdCount++;
             elapsedAdGroupAdDurationUs += periodDurationUs;
-            if (periodStartUs + periodDurationUs == adGroup.timeUs + adGroupDurationUs) {
+            if ((adGroup.originalCount > adGroup.count && adGroup.count == mappedAdCount)
+                || periodStartUs + periodDurationUs == adGroup.timeUs + adGroupDurationUs) {
               // Periods have consumed the ad group. We're at the end of the ad group.
               if (window.isLive()) {
                 // Add elapsed ad duration to elapsed content duration for live streams to account


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed an issue in `ImaUtil` where the splitting algorithm did not correctly handle partial ad groups, leading to incorrect ad period assignments.
- Introduced a `mappedAdCount` variable to accurately track the number of ads mapped in a partial ad group.
- Enhanced the condition to determine the end of an ad group, ensuring correct handling of live streams.
- Added a new test case in `ImaUtilTest` to verify the correct detection of ad periods when a partial ad group ends before the last period.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImaUtil.java</strong><dd><code>Fix ad playback state splitting for partial ad groups</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaUtil.java

<li>Added logic to handle edge cases in ad playback state splitting.<br> <li> Introduced a <code>mappedAdCount</code> variable to track mapped ads.<br> <li> Improved condition to detect the end of an ad group.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/10/files#diff-fb18552ce938e82392f5a18a4443dc1e703ebbc6e98092aff87d222aaf5fdd7e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImaUtilTest.java</strong><dd><code>Add test for partial ad group handling in live streams</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/ima/src/test/java/com/google/android/exoplayer2/ext/ima/ImaUtilTest.java

<li>Added a new test case for partial ad groups ending before the last <br>period.<br> <li> Verified correct detection of ad periods in edge cases.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/ExoPlayer/pull/10/files#diff-7820977ebab36055f2844275a1f0ba73dfd785e503c6f808acacc26289be5421">+40/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information